### PR TITLE
typo in lesson 05 on line 148

### DIFF
--- a/05-X-ray-spectroscopy.jl
+++ b/05-X-ray-spectroscopy.jl
@@ -145,7 +145,7 @@ md"""
 We will start by fitting a photoelectric absorption model that acts on a power law model:
 
 ```julia
-model = PhotoelectricAbsorption() * PowerLaw()
+model1 = PhotoelectricAbsorption() * PowerLaw()
 ```
 """
 


### PR DESCRIPTION
`model` is defined on line 148 but later cells refer to `model1`

Changed `model` to `model1` on line 148